### PR TITLE
Remove [unsupported] comments in app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -6,8 +6,6 @@
     "Imgur"
   ],
   "repository": "https://github.com/dibyadas/imagery",
-  // "logo": "https://small-sharp-tool.com/logo.svg",
-  // "success_url": "/welcome",
   "env": {
     "slack_access_token": {
       "description": "Slack's OAUTH token.",


### PR DESCRIPTION
**Problem:** While deploying to Heroku, I got this error: `The content of app.json is not valid; please see app.json Schema for more information. The file does not contain a valid JSON entity.` 

![image](https://user-images.githubusercontent.com/28287478/49696077-8352b000-fbca-11e8-8448-5eb35674c045.png)

**Solution:** JSON does not support comments. Removing lines with `//` might resolve the issue of deployment.